### PR TITLE
Handle unparsable JSON

### DIFF
--- a/lib/attachinary/orm/active_record/extension.rb
+++ b/lib/attachinary/orm/active_record/extension.rb
@@ -17,7 +17,7 @@ module Attachinary
           dependent: :destroy
       else
         has_many :"#{relation}",
-          -> { where scope: options[:scope].to_s }, 
+          -> { where scope: options[:scope].to_s },
           as: :attachinariable,
           class_name: '::Attachinary::File',
           dependent: :destroy
@@ -37,6 +37,9 @@ module Attachinary
         input = Attachinary::Utils.process_input(input, upload_options, options[:scope])
         if input.nil?
           send("#{relation}").clear
+        elsif input.blank?
+          errors.add(:base, "unable to process #{options[:scope]}".humanize)
+          nil
         else
           files = [input].flatten
           send("#{relation}=", files)

--- a/lib/attachinary/orm/mongoid/extension.rb
+++ b/lib/attachinary/orm/mongoid/extension.rb
@@ -36,6 +36,12 @@ module Attachinary
           input = [input].flatten
           input = (options[:single] ? input[0] : input)
         end
+
+        if input.blank?
+          errors.add(:base, "unable to process #{options[:scope]}".humanize)
+          return nil
+        end
+
         send("orig_#{options[:scope]}=", input)
       end
     end

--- a/lib/attachinary/utils.rb
+++ b/lib/attachinary/utils.rb
@@ -2,7 +2,19 @@ module Attachinary
   module Utils
 
     def self.process_json(json, scope=nil)
-      [JSON.parse(json)].flatten.compact.map do |data|
+      parsed_json = begin
+        [JSON.parse(json)]
+      rescue JSON::ParserError
+        ''
+      end
+
+      # If we couldn't parse the JSON, return an empty string. We
+      # don't want to return a nil value here, otherwise the gem will
+      # think we want to clear the current value. We simply want to
+      # add an error
+      return parsed_json if parsed_json.blank?
+
+      parsed_json.flatten.compact.map do |data|
         process_hash(data, scope)
       end
     end

--- a/spec/models/note_spec.rb
+++ b/spec/models/note_spec.rb
@@ -16,13 +16,13 @@ describe Note do
       after(:each) do
         Cloudinary.config.delete_field(:attachinary_keep_remote) if Cloudinary.config.respond_to?(:attachinary_keep_remote)
       end
-      
+
       it "destroys attached files" do
         note = create(:note, photo: photo)
         Cloudinary::Uploader.should_receive(:destroy).with(photo.public_id)
         note.destroy
       end
-      
+
       it "keeps attached files if Cloudinary.config.attachinary_keep_remote == true" do
         Cloudinary.config.attachinary_keep_remote = true
         note = create(:note, photo: photo)
@@ -64,6 +64,15 @@ describe Note do
         file = build(:file)
         subject.photo = "[null]"
         subject.photo.should be_nil
+      end
+
+      it 'adds errors for unparseable JSON' do
+        file = build(:file)
+        subject.photo = file.to_json
+        subject.photo.public_id.should == file.public_id
+        subject.photo = "non-JSON string"
+        subject.photo.public_id.should == file.public_id
+        subject.errors.messages_for(:base).should include('Unable to process photo')
       end
 
       it 'accepts IO objects' do


### PR DESCRIPTION
Makes it possible for parsing a string as a JSON to fail gracefully. When it does, it will add an error to the model.